### PR TITLE
[Bugfix] Fix QDropout

### DIFF
--- a/actnn/actnn/cpp_extension/quantization.cc
+++ b/actnn/actnn/cpp_extension/quantization.cc
@@ -30,7 +30,7 @@ Tensor act_quantized_relu_backward_cuda(Tensor grad_output, Tensor mask);
 
 // ActQuantizedDropout
 std::pair<Tensor, Tensor> act_quantized_dropout_forward_cuda(Tensor data, float dropout_p);
-Tensor act_quantized_dropout_backward_cuda(Tensor grad_output, Tensor mask);
+Tensor act_quantized_dropout_backward_cuda(Tensor grad_output, Tensor mask, float dropout_p);
 
 // ActQuantizedMaxPool2d
 std::pair<Tensor, Tensor> act_quantized_max_pool2d_forward_cuda(Tensor input,
@@ -131,12 +131,14 @@ class ActQuantizedDropout : public Function<ActQuantizedDropout> {
     Tensor output, mask;
     std::tie(output, mask) = act_quantized_dropout_forward_cuda(input, dropout_p);
     ctx->save_for_backward({mask});
+    ctx->saved_data["dropout_p"] = dropout_p;
     return output;
   }
 
   static tensor_list backward(AutogradContext *ctx, tensor_list grad_outputs) {
     auto saved = ctx->get_saved_variables();
-    return {act_quantized_dropout_backward_cuda(grad_outputs[0], saved[0]), Tensor()};
+    float dropout_p = float(ctx->saved_data["dropout_p"].toDouble());
+    return {act_quantized_dropout_backward_cuda(grad_outputs[0], saved[0], dropout_p), Tensor()};
   }
 };
 

--- a/actnn/actnn/cpp_extension/quantization_cuda_kernel.cu
+++ b/actnn/actnn/cpp_extension/quantization_cuda_kernel.cu
@@ -589,7 +589,8 @@ template <typename scalar_t>
 __global__ void act_quantized_dropout_backward_kernel(const scalar_t* __restrict__ grad_output,
                                                    int32_t* __restrict__ mask,
                                                    scalar_t* __restrict__ grad_input,
-                                                   int N) {
+                                                   int N,
+                                                   float dropout_p) {
   int64_t id = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
   const int64_t global_offset = (int64_t)blockIdx.x * blockDim.x / (sizeof(int32_t) * 8);
   const int shared_len = ACT_QUANTIZED_DROPOUT_NUM_THREADS / (sizeof(int32_t) * 8);
@@ -597,7 +598,7 @@ __global__ void act_quantized_dropout_backward_kernel(const scalar_t* __restrict
   if (id < N) {
     bool bit =  (mask[global_offset + threadIdx.x % shared_len] >> (threadIdx.x / shared_len)) & 1;
     if (bit) {
-      grad_input[id] = grad_output[id];
+      grad_input[id] = grad_output[id] / (1.0 - dropout_p);;
     } else {
       grad_input[id] = 0.0;
     }
@@ -605,7 +606,7 @@ __global__ void act_quantized_dropout_backward_kernel(const scalar_t* __restrict
 }
 
 
-Tensor act_quantized_dropout_backward_cuda(Tensor grad_output, Tensor mask) {
+Tensor act_quantized_dropout_backward_cuda(Tensor grad_output, Tensor mask, float dropout_p) {
   int64_t n_elements = 1;
   for (size_t i = 0; i < grad_output.dim(); ++i) {
     n_elements *= grad_output.size(i);
@@ -619,7 +620,7 @@ Tensor act_quantized_dropout_backward_cuda(Tensor grad_output, Tensor mask) {
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad_output.scalar_type(), "act_quantized_dropout_backward", ([&] {
       act_quantized_dropout_backward_kernel<scalar_t><<<blocks, threads>>>(
         grad_output.data_ptr<scalar_t>(), mask.data_ptr<int32_t>(), grad_input.data_ptr<scalar_t>(),
-        n_elements);
+        n_elements, dropout_p);
   }));
 
   return grad_input;

--- a/actnn/actnn/layers.py
+++ b/actnn/actnn/layers.py
@@ -369,13 +369,16 @@ class QReLU(nn.Module):
         return ext_quantization.act_quantized_relu(input)
 
 
-class QDropout(nn.Module):
+class QDropout(nn.Dropout):
     def __init__(self, p=0.5):
-        super().__init__()
+        super().__init__(p=p)
         self.p = p
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-        return ext_quantization.act_quantized_dropout(input, self.p)
+        if self.training:
+            return ext_quantization.act_quantized_dropout(input, self.p)
+        else:
+            return super(QDropout, self).forward(input)
 
 
 class QSyncBatchNorm(nn.SyncBatchNorm):


### PR DESCRIPTION
Hi, I find some bugs of my early implementation when using QDropout. 
1. In the backward, the gradient should also be divided by the `1-p` factor. 
2. In the validation step (`self.training = False`), we can directly use the forward of `nn.Dropout` since dropout performs different in training and validation steps. 

Please help check the modification.